### PR TITLE
warning: 'checkMimeTypeView' overrides a member function but is not marked 'override'

### DIFF
--- a/cpp/android/androidshareutils.hpp
+++ b/cpp/android/androidshareutils.hpp
@@ -14,17 +14,17 @@ class AndroidShareUtils : public PlatformShareUtils, public QAndroidActivityResu
 {
 public:
     AndroidShareUtils(QObject* parent = 0);
-    bool checkMimeTypeView(const QString &mimeType);
-    bool checkMimeTypeEdit(const QString &mimeType);
+    bool checkMimeTypeView(const QString &mimeType) override;
+    bool checkMimeTypeEdit(const QString &mimeType) override;
     void share(const QString &text, const QUrl &url) override;
     void sendFile(const QString &filePath, const QString &title, const QString &mimeType, const int &requestId, const bool &altImpl) override;
     void viewFile(const QString &filePath, const QString &title, const QString &mimeType, const int &requestId, const bool &altImpl) override;
     void editFile(const QString &filePath, const QString &title, const QString &mimeType, const int &requestId, const bool &altImpl) override;
 
-    void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data);
+    void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data) override;
     void onActivityResult(int requestCode, int resultCode);
 
-    void checkPendingIntents(const QString workingDirPath);
+    void checkPendingIntents(const QString workingDirPath) override;
 
     static AndroidShareUtils* getInstance();
 


### PR DESCRIPTION
This fix warning messages for build with clang (android):

```
In file included from shareutils.cpp:12:
./androidshareutils.hpp:17:10: warning: 'checkMimeTypeView' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool checkMimeTypeView(const QString &mimeType);
         ^
./shareutils.hpp:37:18: note: overridden virtual function is here
    virtual bool checkMimeTypeView(const QString &mimeType){
                 ^
In file included from shareutils.cpp:12:
./androidshareutils.hpp:18:10: warning: 'checkMimeTypeEdit' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool checkMimeTypeEdit(const QString &mimeType);
         ^
./shareutils.hpp:40:18: note: overridden virtual function is here
    virtual bool checkMimeTypeEdit(const QString &mimeType){
                 ^
In file included from shareutils.cpp:12:
./androidshareutils.hpp:24:10: warning: 'handleActivityResult' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data);
         ^
/usr/local/Qt-5.13.1/include/QtAndroidExtras/qandroidactivityresultreceiver.h:54:18: note: overridden virtual function is here
    virtual void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data) = 0;
                 ^
In file included from shareutils.cpp:12:
./androidshareutils.hpp:27:10: warning: 'checkPendingIntents' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void checkPendingIntents(const QString workingDirPath);
         ^
./shareutils.hpp:51:18: note: overridden virtual function is here
    virtual void checkPendingIntents(const QString workingDirPath){
                 ^
4 warnings generated.

In file included from androidshareutils.cpp:5:
./androidshareutils.hpp:17:10: warning: 'checkMimeTypeView' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool checkMimeTypeView(const QString &mimeType);
         ^
./shareutils.hpp:37:18: note: overridden virtual function is here
    virtual bool checkMimeTypeView(const QString &mimeType){
                 ^
In file included from androidshareutils.cpp:5:
./androidshareutils.hpp:18:10: warning: 'checkMimeTypeEdit' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool checkMimeTypeEdit(const QString &mimeType);
         ^
./shareutils.hpp:40:18: note: overridden virtual function is here
    virtual bool checkMimeTypeEdit(const QString &mimeType){
                 ^
In file included from androidshareutils.cpp:5:
./androidshareutils.hpp:24:10: warning: 'handleActivityResult' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data);
         ^
/usr/local/Qt-5.13.1/include/QtAndroidExtras/qandroidactivityresultreceiver.h:54:18: note: overridden virtual function is here
    virtual void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data) = 0;
                 ^
In file included from androidshareutils.cpp:5:
./androidshareutils.hpp:27:10: warning: 'checkPendingIntents' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void checkPendingIntents(const QString workingDirPath);
         ^
./shareutils.hpp:51:18: note: overridden virtual function is here
    virtual void checkPendingIntents(const QString workingDirPath){
                 ^
4 warnings generated.

```